### PR TITLE
Add papercolor themes

### DIFF
--- a/base16-papercolor.dark.sh
+++ b/base16-papercolor.dark.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Base16 PaperColor-Dark - Gnome Terminal color scheme install script
+# Nguyen Nguyen (http://github.com/NLKNguyen)
+
+[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 PaperColor Dark"
+[[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG="base-16-papercolor-dark"
+[[ -z "$DCONF" ]] && DCONF=dconf
+[[ -z "$UUIDGEN" ]] && UUIDGEN=uuidgen
+
+dset() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    if [[ "$type" == "string" ]]; then
+        val="'$val'"
+    fi
+
+    "$DCONF" write "$PROFILE_KEY/$key" "$val"
+}
+
+# because dconf still doesn't have "append"
+dlist_append() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$DCONF" read "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "'$val'"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$DCONF" write "$key" "[$entries]"
+}
+
+# Newest versions of gnome-terminal use dconf
+if which "$DCONF" > /dev/null 2>&1; then
+    [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
+
+    if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then
+        if which "$UUIDGEN" > /dev/null 2>&1; then
+            PROFILE_SLUG=`uuidgen`
+        fi
+
+        if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
+            DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
+        else
+            DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
+        fi
+
+        DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
+        PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
+
+        # copy existing settings from default profile
+        $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
+
+        # add new copy to list of profiles
+        dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
+
+        # update profile values with theme options
+        dset visible-name "'$PROFILE_NAME'"
+        dset palette "['#262626', '#af87af', '#dfaf5f', '#00afaf', '#df875f', '#afdf00', '#5fafdf', '#d0d0d0', '#808080', '#af87af', '#dfaf5f', '#00afaf', '#df875f', '#afdf00', '#5fafdf', '#f3f3f3']"
+        dset background-color "'#262626'"
+        dset foreground-color "'#d0d0d0'"
+        dset bold-color "'#d0d0d0'"
+        dset bold-color-same-as-fg "true"
+        dset use-theme-colors "false"
+        dset use-theme-background "false"
+
+        unset PROFILE_NAME
+        unset PROFILE_SLUG
+        unset DCONF
+        unset UUIDGEN
+        exit 0
+    fi
+fi
+
+# Fallback for Gnome 2 and early Gnome 3
+[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gconftool
+[[ -z "$BASE_KEY" ]] && BASE_KEY=/apps/gnome-terminal/profiles
+
+PROFILE_KEY="$BASE_KEY/$PROFILE_SLUG"
+
+gset() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    "$GCONFTOOL" --set --type "$type" "$PROFILE_KEY/$key" -- "$val"
+}
+
+# Because gconftool doesn't have "append"
+glist_append() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$GCONFTOOL" --get "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "$val"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$GCONFTOOL" --set --type list --list-type $type "$key" "[$entries]"
+}
+
+# Append the Base16 profile to the profile list
+glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
+
+gset string visible_name "$PROFILE_NAME"
+gset string palette "#262626:#af87af:#dfaf5f:#00afaf:#df875f:#afdf00:#5fafdf:#d0d0d0:#808080:#af87af:#dfaf5f:#00afaf:#df875f:#afdf00:#5fafdf:#f3f3f3"
+gset string background_color "#262626"
+gset string foreground_color "#d0d0d0"
+gset string bold_color "#d0d0d0"
+gset bool   bold_color_same_as_fg "true"
+gset bool   use_theme_colors "false"
+gset bool   use_theme_background "false"
+
+unset PROFILE_NAME
+unset PROFILE_SLUG
+unset DCONF
+unset UUIDGEN

--- a/base16-papercolor.light.sh
+++ b/base16-papercolor.light.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Base16 PaperColor-Light - Gnome Terminal color scheme install script
+# Nguyen Nguyen (http://github.com/NLKNguyen)
+
+[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 PaperColor Light"
+[[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG="base-16-papercolor-light"
+[[ -z "$DCONF" ]] && DCONF=dconf
+[[ -z "$UUIDGEN" ]] && UUIDGEN=uuidgen
+
+dset() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    if [[ "$type" == "string" ]]; then
+        val="'$val'"
+    fi
+
+    "$DCONF" write "$PROFILE_KEY/$key" "$val"
+}
+
+# because dconf still doesn't have "append"
+dlist_append() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$DCONF" read "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "'$val'"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$DCONF" write "$key" "[$entries]"
+}
+
+# Newest versions of gnome-terminal use dconf
+if which "$DCONF" > /dev/null 2>&1; then
+    [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
+
+    if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then
+        if which "$UUIDGEN" > /dev/null 2>&1; then
+            PROFILE_SLUG=`uuidgen`
+        fi
+
+        if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
+            DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
+        else
+            DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
+        fi
+
+        DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
+        PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
+
+         # copy existing settings from default profile
+        $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
+
+        # add new copy to list of profiles
+        dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
+
+        # update profile values with theme options
+        dset visible-name "'$PROFILE_NAME'"
+        dset palette "'#262626:#8959a8:#718c00:#4271ae:#005f87:#d7005f:#3e999f:#d0d0d0:#808080:#8959a8:#718c00:#4271ae:#005f87:#d7005f:#3e999f:#f3f3f3'"
+        dset palette "'#f3f3f3:#8959a8:#718c00:#4271ae:#005f87:#d7005f:#3e999f:#d0d0d0:#808080:#8959a8:#718c00:#4271ae:#005f87:#d7005f:#3e999f:#262626'"
+        dset background-color "'#f3f3f3'"
+        dset foreground-color "'#4d4d4c'"
+        dset bold-color "'#4d4d4c'"
+        dset bold-color-same-as-fg "true"
+        dset use-theme-colors "false"
+        dset use-theme-background "false"
+
+        unset PROFILE_NAME
+        unset PROFILE_SLUG
+        unset DCONF
+        unset UUIDGEN
+        exit 0
+    fi
+fi
+
+# Fallback for Gnome 2 and early Gnome 3
+[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gconftool
+[[ -z "$BASE_KEY" ]] && BASE_KEY=/apps/gnome-terminal/profiles
+
+PROFILE_KEY="$BASE_KEY/$PROFILE_SLUG"
+
+gset() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    "$GCONFTOOL" --set --type "$type" "$PROFILE_KEY/$key" -- "$val"
+}
+
+# Because gconftool doesn't have "append"
+glist_append() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$GCONFTOOL" --get "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "$val"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$GCONFTOOL" --set --type list --list-type $type "$key" "[$entries]"
+}
+
+# Append the Base16 profile to the profile list
+glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
+
+gset string visible_name "$PROFILE_NAME"
+gset string palette "#f3f3f3:#8959a8:#718c00:#4271ae:#005f87:#d7005f:#3e999f:#d0d0d0:#808080:#8959a8:#718c00:#4271ae:#005f87:#d7005f:#3e999f:#262626"
+gset string background_color "#f3f3f3"
+gset string foreground_color "#4d4d4c"
+gset string bold_color "#4d4d4c"
+gset bool   bold_color_same_as_fg "true"
+gset bool   use_theme_colors "false"
+gset bool   use_theme_background "false"
+
+unset PROFILE_NAME
+unset PROFILE_SLUG
+unset DCONF
+unset UUIDGEN


### PR DESCRIPTION
GNOME Terminal color schemes (light & dark) based on [PaperColor](https://github.com/NLKNguyen/papercolor-theme/)