### PR TITLE
Added Material color scheme based on equinusocio/material-theme

### DIFF
--- a/base16-material.light.sh
+++ b/base16-material.light.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Base16 Material Light - Gnome Terminal color scheme install script
+
+[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 Material Light"
+[[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG="base-16-material-light"
+[[ -z "$DCONF" ]] && DCONF=dconf
+[[ -z "$UUIDGEN" ]] && UUIDGEN=uuidgen
+
+dset() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    if [[ "$type" == "string" ]]; then
+        val="'$val'"
+    fi
+
+    "$DCONF" write "$PROFILE_KEY/$key" "$val"
+}
+
+# because dconf still doesn't have "append"
+dlist_append() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$DCONF" read "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "'$val'"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$DCONF" write "$key" "[$entries]"
+}
+
+# Newest versions of gnome-terminal use dconf
+if which "$DCONF" > /dev/null 2>&1; then
+    [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
+
+    if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then
+        if which "$UUIDGEN" > /dev/null 2>&1; then
+            PROFILE_SLUG=`uuidgen`
+        fi
+
+        if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
+            DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
+        else
+            DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
+        fi
+
+        DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
+        PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
+
+        # copy existing settings from default profile
+        $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
+
+        # add new copy to list of profiles
+        dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
+
+        # update profile values with theme options
+        dset visible-name "'$PROFILE_NAME'"
+        dset palette "['#263238', '#cc6666', '#b5bd68', '#f0c674', '#81a2be', '#b294bb', '#8abeb7', '#ecefef', '#707880', '#cc6666', '#263238', '#37474f', '#b5bd68', '#ecefef', '#cc6666', '#ffffff']"
+        dset background-color "'#ffffff'"
+        dset foreground-color "'#37474f'"
+        dset bold-color "'#37474f'"
+        dset bold-color-same-as-fg "true"
+        dset use-theme-colors "false"
+        dset use-theme-background "false"
+
+        unset PROFILE_NAME
+        unset PROFILE_SLUG
+        unset DCONF
+        unset UUIDGEN
+        exit 0
+    fi
+fi
+
+# Fallback for Gnome 2 and early Gnome 3
+[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gconftool
+[[ -z "$BASE_KEY" ]] && BASE_KEY=/apps/gnome-terminal/profiles
+
+PROFILE_KEY="$BASE_KEY/$PROFILE_SLUG"
+
+gset() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    "$GCONFTOOL" --set --type "$type" "$PROFILE_KEY/$key" -- "$val"
+}
+
+# Because gconftool doesn't have "append"
+glist_append() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$GCONFTOOL" --get "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "$val"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$GCONFTOOL" --set --type list --list-type $type "$key" "[$entries]"
+}
+
+# Append the Base16 profile to the profile list
+glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
+
+gset string visible_name "$PROFILE_NAME"
+gset string palette "#263238:#cc6666:#b5bd68:#f0c674:#81a2be:#b294bb:#8abeb7:#ecefef:#707880:#cc6666:#263238:#37474f:#b5bd68:#ecefef:#cc6666:#263238"
+gset string background_color "#ffffff"
+gset string foreground_color "#37474f"
+gset string bold_color "#37474f"
+gset bool   bold_color_same_as_fg "true"
+gset bool   use_theme_colors "false"
+gset bool   use_theme_background "false"
+
+unset PROFILE_NAME
+unset PROFILE_SLUG
+unset DCONF
+unset UUIDGEN

--- a/base16-material.sh
+++ b/base16-material.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Base16 Material - Gnome Terminal color scheme install script
+
+[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 Material"
+[[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG="base-16-material"
+[[ -z "$DCONF" ]] && DCONF=dconf
+[[ -z "$UUIDGEN" ]] && UUIDGEN=uuidgen
+
+dset() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    if [[ "$type" == "string" ]]; then
+        val="'$val'"
+    fi
+
+    "$DCONF" write "$PROFILE_KEY/$key" "$val"
+}
+
+# because dconf still doesn't have "append"
+dlist_append() {
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$DCONF" read "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "'$val'"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$DCONF" write "$key" "[$entries]"
+}
+
+# Newest versions of gnome-terminal use dconf
+if which "$DCONF" > /dev/null 2>&1; then
+    [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
+
+    if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then
+        if which "$UUIDGEN" > /dev/null 2>&1; then
+            PROFILE_SLUG=`uuidgen`
+        fi
+
+        if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
+            DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
+        else
+            DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
+        fi
+
+        DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
+        PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
+
+        # copy existing settings from default profile
+        $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
+
+        # add new copy to list of profiles
+        dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
+
+        # update profile values with theme options
+        dset visible-name "'$PROFILE_NAME'"
+        dset palette "['#073642', '#eb606b', '#c3e88d', '#f7eb95', '#80cbc4', '#ff2490', '#aeddff', '#ffffff', '#ff002b', '#eb606b', '#c3e88d', '#f7eb95', '#7dc6bf', '#6c71c4', '#35434d', '#ffffff']"
+        dset background-color "'#1e282d'"
+        dset foreground-color "'#c4c7d1'"
+        dset bold-color "'#c4c7d1'"
+        dset bold-color-same-as-fg "true"
+        dset use-theme-colors "false"
+        dset use-theme-background "false"
+
+        unset PROFILE_NAME
+        unset PROFILE_SLUG
+        unset DCONF
+        unset UUIDGEN
+        exit 0
+    fi
+fi
+
+# Fallback for Gnome 2 and early Gnome 3
+[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gconftool
+[[ -z "$BASE_KEY" ]] && BASE_KEY=/apps/gnome-terminal/profiles
+
+PROFILE_KEY="$BASE_KEY/$PROFILE_SLUG"
+
+gset() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    "$GCONFTOOL" --set --type "$type" "$PROFILE_KEY/$key" -- "$val"
+}
+
+# Because gconftool doesn't have "append"
+glist_append() {
+    local type="$1"; shift
+    local key="$1"; shift
+    local val="$1"; shift
+
+    local entries="$(
+        {
+            "$GCONFTOOL" --get "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+            echo "$val"
+        } | head -c-1 | tr "\n" ,
+    )"
+
+    "$GCONFTOOL" --set --type list --list-type $type "$key" "[$entries]"
+}
+
+# Append the Base16 profile to the profile list
+glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
+
+gset string visible_name "$PROFILE_NAME"
+gset string palette "#073642:#eb606b:#c3e88d:#f7eb95:#80cbc4:#ff2490:#aeddff:#ffffff:#ff002b:#eb606b:#c3e88d:#f7eb95:#7dc6bf:#6c71c4:#35434d:#ffffff"
+gset string background_color "#1e282d"
+gset string foreground_color "#c4c7d1"
+gset string bold_color "#c4c7d1"
+gset bool   bold_color_same_as_fg "true"
+gset bool   use_theme_colors "false"
+gset bool   use_theme_background "false"
+
+unset PROFILE_NAME
+unset PROFILE_SLUG
+unset DCONF
+unset UUIDGEN


### PR DESCRIPTION
I use material theme in Sublime Text, Atom and recently I started using it in Vim. 
I've ported the colors scheme from sublime text to Gnome terminal. 

The script is made with https://terminal.sexy/ and is working fine in gnome terminal 3.18.2

Original credits to https://github.com/equinusocio/material-theme